### PR TITLE
New method parseSafe with error codes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change History
 
-1.11 TO BE RELEASED
+1.12 TO BE RELEASED
+ - new method parseSafe with error codes
  - Fix spelling mistake in pod (RT #70052)
 
 1.10 2009-12-02

--- a/t/error.t
+++ b/t/error.t
@@ -6,10 +6,21 @@ use Test::Exception;
 use_ok( 'CQL::Parser' );
 my $parser = CQL::Parser->new();
 
-throws_ok
-    { $parser->parse( 'foo and' ) }
-    qr/missing term/,
-    'missing term';
+my %tests = (
+    'foo and'  => [ 27, qr/missing term/ ],
+    'foo !'    => [ 19, qr/unknown first class relation/ ],
+);
 
 ## TODO: should add more errors here
+
+foreach my $test (sort keys %tests) {
+    my ($code,$regexp) = @{ $tests{$test} };
+
+    throws_ok
+        { $parser->parse( $test ) }
+        $regexp,
+        $test;
+
+    is $parser->parseSafe( $test ), $code, "code $code";
+}
 


### PR DESCRIPTION
This moves duplicated code from `Catalyst::Controller::SRU` and `SRU::Server` to `CQL::Parser`.
